### PR TITLE
Added pauri and pauri_translation models and migrations

### DIFF
--- a/app/models/chhand.rb
+++ b/app/models/chhand.rb
@@ -3,4 +3,5 @@
 class Chhand < ApplicationRecord
   belongs_to :chhand_type
   belongs_to :chapter
+  has_many :pauris, :dependent => :destroy
 end

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
 class Pauri < ApplicationRecord
-    belongs_to :chapter
+  belongs_to :chapter
+  has_one :translation, :class_name => 'pauri_translation', :dependent => :destroy
 end

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -1,0 +1,3 @@
+class Pauri < ApplicationRecord
+    belongs_to :chapter
+end

--- a/app/models/pauri_translation.rb
+++ b/app/models/pauri_translation.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
 class PauriTranslation < ApplicationRecord
+  belongs_to :pauri
 end

--- a/app/models/pauri_translation.rb
+++ b/app/models/pauri_translation.rb
@@ -1,0 +1,2 @@
+class PauriTranslation < ApplicationRecord
+end

--- a/db/migrate/20230405183333_create_pauris.rb
+++ b/db/migrate/20230405183333_create_pauris.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class CreatePauris < ActiveRecord::Migration[7.0]
   def change
     create_table :pauris do |t|
       t.integer :number
       t.references :chapter, :foreign_key => true, :null => false
       t.references :chhand, :foreign_key => true, :null => false
-      
+
       t.timestamps
     end
   end

--- a/db/migrate/20230405183333_create_pauris.rb
+++ b/db/migrate/20230405183333_create_pauris.rb
@@ -1,0 +1,11 @@
+class CreatePauris < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pauris do |t|
+      t.integer :number
+      t.references :chapter, :foreign_key => true, :null => false
+      t.references :chhand, :foreign_key => true, :null => false
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230406180334_create_pauri_translations.rb
+++ b/db/migrate/20230406180334_create_pauri_translations.rb
@@ -1,0 +1,11 @@
+class CreatePauriTranslations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pauri_translations do |t|
+      t.string :en_translation
+      t.string :en_translator
+      t.references :pauri, :foreign_key => true, :null => false
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230406180334_create_pauri_translations.rb
+++ b/db/migrate/20230406180334_create_pauri_translations.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class CreatePauriTranslations < ActiveRecord::Migration[7.0]
   def change
     create_table :pauri_translations do |t|
       t.string :en_translation
       t.string :en_translator
       t.references :pauri, :foreign_key => true, :null => false
-      
+
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_26_064945) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_06_180334) do
   create_table "books", force: :cascade do |t|
     t.integer "sequence", null: false
     t.string "title", null: false
@@ -55,7 +55,29 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_26_064945) do
     t.index ["chhand_type_id"], name: "index_chhands_on_chhand_type_id"
   end
 
+  create_table "pauri_translations", force: :cascade do |t|
+    t.string "en_translation"
+    t.string "en_translator"
+    t.integer "pauri_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pauri_id"], name: "index_pauri_translations_on_pauri_id"
+  end
+
+  create_table "pauris", force: :cascade do |t|
+    t.integer "number"
+    t.integer "chapter_id", null: false
+    t.integer "chhand_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chapter_id"], name: "index_pauris_on_chapter_id"
+    t.index ["chhand_id"], name: "index_pauris_on_chhand_id"
+  end
+
   add_foreign_key "chapters", "books"
   add_foreign_key "chhands", "chapters"
   add_foreign_key "chhands", "chhand_types"
+  add_foreign_key "pauri_translations", "pauris"
+  add_foreign_key "pauris", "chapters"
+  add_foreign_key "pauris", "chhands"
 end

--- a/spec/factories/pauri_translations.rb
+++ b/spec/factories/pauri_translations.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :pauri_translation do
-    
+    # TODO: Add `pauri_translation` factory
   end
 end

--- a/spec/factories/pauri_translations.rb
+++ b/spec/factories/pauri_translations.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :pauri_translation do
+    
+  end
+end

--- a/spec/factories/pauris.rb
+++ b/spec/factories/pauris.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :pauri do
-    
+    # TODO: Add `pauri` factory
   end
 end

--- a/spec/factories/pauris.rb
+++ b/spec/factories/pauris.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :pauri do
+    
+  end
+end

--- a/spec/models/pauri_spec.rb
+++ b/spec/models/pauri_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe Pauri, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+require 'rails_helper'

--- a/spec/models/pauri_spec.rb
+++ b/spec/models/pauri_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Pauri, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/pauri_translation_spec.rb
+++ b/spec/models/pauri_translation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PauriTranslation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/pauri_translation_spec.rb
+++ b/spec/models/pauri_translation_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe PauriTranslation, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+require 'rails_helper'


### PR DESCRIPTION
Added appropriate fields for `pauri` and `pauri_translation` models in their migrations. Also modified their models such that one `chhand` can have many `pauris`, but one `pauri` belongs to only one `chhand`.

Closes #19 