### PR TITLE
Add specs for `Chhand` and `ChhandType`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,5 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 
-.vscode
 .trunk
 .env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,3 +97,6 @@ Layout/EmptyLineAfterGuardClause:
 
 RSpec/ExpectChange:
   Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,3 +94,6 @@ Style/WordArray:
 
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
+
+RSpec/ExpectChange:
+  Enabled: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "editor.tabSize": 2,
+  "editor.defaultFormatter": "LoranKloeze.ruby-rubocop-revived",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.rubocop": true
+  },
+  "ruby.rubocop.autocorrectOnSave": true,
+  "ruby.rubocop.useServer": true,
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+}

--- a/app/models/chhand_type.rb
+++ b/app/models/chhand_type.rb
@@ -2,4 +2,7 @@
 
 class ChhandType < ApplicationRecord
   has_many :chhands, :dependent => :destroy
+
+  validates :name, :presence => true
+  validates :name, :uniqueness => true
 end

--- a/db/migrate/20230407102145_add_unique_index_on_chhand_type_name.rb
+++ b/db/migrate/20230407102145_add_unique_index_on_chhand_type_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnChhandTypeName < ActiveRecord::Migration[7.0]
+  def change
+    add_index :chhand_types, :name, :unique => true
+  end
+end

--- a/db/migrate/20230407102145_add_unique_index_on_chhand_type_name.rb
+++ b/db/migrate/20230407102145_add_unique_index_on_chhand_type_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUniqueIndexOnChhandTypeName < ActiveRecord::Migration[7.0]
   def change
     add_index :chhand_types, :name, :unique => true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_26_064945) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_07_102145) do
   create_table "books", force: :cascade do |t|
     t.integer "sequence", null: false
     t.string "title", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_26_064945) do
     t.string "en_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_chhand_types_on_name", unique: true
   end
 
   create_table "chhands", force: :cascade do |t|

--- a/spec/factories/chhand_types.rb
+++ b/spec/factories/chhand_types.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :chhand_type do
-    # TODO: Add chhand_type factory
+    name { 'ਦੋਹਰਾ' }
+    en_name { 'Dohra' }
   end
 end

--- a/spec/factories/chhands.rb
+++ b/spec/factories/chhands.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :chhand do
-    # TODO: Add `chhand` factory
+    association :chhand_type
+    association :chapter
   end
 end

--- a/spec/models/chhand_spec.rb
+++ b/spec/models/chhand_spec.rb
@@ -8,44 +8,44 @@ RSpec.describe Chhand do
 
   describe 'validations' do
     context 'when given valid attributes' do
-      it 'saves the chhand' do
+      it 'saves the `Chhand`' do
         chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :vaak => 'Example vaak')
         expect(chhand).to be_valid
       end
 
-      it 'saves the chhand without vaak' do
+      it 'saves the `Chhand` without `vaak`' do
         chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter)
         expect(chhand).to be_valid
       end
     end
 
     context 'when given invalid attributes' do
-      it 'does not save the chhand without a chhand_type' do
+      it 'does not save the `Chhand` without a `chhand_type`' do
         chhand = Chhand.new(:chapter => chapter, :vaak => 'Example vaak')
         expect(chhand).not_to be_valid
       end
 
-      it 'does not save the chhand without a chapter' do
+      it 'does not save the `Chhand` without a `chapter`' do
         chhand = Chhand.new(:chhand_type => chhand_type, :vaak => 'Example vaak')
         expect(chhand).not_to be_valid
       end
 
-      it 'does not save the chhand with a non-existent chhand_type' do
+      it 'does not save the `Chhand` with a non-existent `chhand_type_id`' do
         chhand = Chhand.new(:chhand_type_id => 999, :chapter => chapter, :vaak => 'Example vaak')
         expect(chhand).not_to be_valid
       end
 
-      it 'does not save the chhand with a non-existent chapter' do
+      it 'does not save the `Chhand` with a non-existent `chapter_id`' do
         chhand = Chhand.new(:chhand_type => chhand_type, :chapter_id => 999, :vaak => 'Example vaak')
         expect(chhand).not_to be_valid
       end
 
-      it 'does not save the chhand with a null chhand_type' do
+      it 'does not save the `Chhand` with a null `chhand_type`' do
         chhand = Chhand.new(:chhand_type => nil, :chapter => chapter, :vaak => 'Example vaak')
         expect(chhand).not_to be_valid
       end
 
-      it 'does not save the chhand with a null chapter' do
+      it 'does not save the `Chhand` with a null `chapter`' do
         chhand = Chhand.new(:chhand_type => chhand_type, :chapter => nil, :vaak => 'Example vaak')
         expect(chhand).not_to be_valid
       end

--- a/spec/models/chhand_spec.rb
+++ b/spec/models/chhand_spec.rb
@@ -1,3 +1,54 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+RSpec.describe Chhand do
+  let(:chhand_type) { create(:chhand_type) }
+  let(:chapter) { create(:chapter) }
+
+  describe 'validations' do
+    context 'when given valid attributes' do
+      it 'saves the chhand' do
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :vaak => 'Example vaak')
+        expect(chhand).to be_valid
+      end
+
+      it 'saves the chhand without vaak' do
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter)
+        expect(chhand).to be_valid
+      end
+    end
+
+    context 'when given invalid attributes' do
+      it 'does not save the chhand without a chhand_type' do
+        chhand = Chhand.new(:chapter => chapter, :vaak => 'Example vaak')
+        expect(chhand).not_to be_valid
+      end
+
+      it 'does not save the chhand without a chapter' do
+        chhand = Chhand.new(:chhand_type => chhand_type, :vaak => 'Example vaak')
+        expect(chhand).not_to be_valid
+      end
+
+      it 'does not save the chhand with a non-existent chhand_type' do
+        chhand = Chhand.new(:chhand_type_id => 999, :chapter => chapter, :vaak => 'Example vaak')
+        expect(chhand).not_to be_valid
+      end
+
+      it 'does not save the chhand with a non-existent chapter' do
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter_id => 999, :vaak => 'Example vaak')
+        expect(chhand).not_to be_valid
+      end
+
+      it 'does not save the chhand with a null chhand_type' do
+        chhand = Chhand.new(:chhand_type => nil, :chapter => chapter, :vaak => 'Example vaak')
+        expect(chhand).not_to be_valid
+      end
+
+      it 'does not save the chhand with a null chapter' do
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => nil, :vaak => 'Example vaak')
+        expect(chhand).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/chhand_type_spec.rb
+++ b/spec/models/chhand_type_spec.rb
@@ -1,3 +1,35 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+RSpec.describe ChhandType do
+  describe 'validations' do
+    it 'saves a valid `chhand_type` when we pass in the name that is written in Gurmukhi' do
+      chhand_type = build(:chhand_type, :name => 'ਪੰਚਮਿ ਪਦ', :en_name => 'Fifth Stanza')
+      expect(chhand_type.save).to be true
+    end
+
+    it 'does not save a `chhand_type` if we pass in an invalid, non-existent value for `name`' do
+      chhand_type = build(:chhand_type, :name => '', :en_name => 'Invalid')
+      expect(chhand_type.save).to be false
+    end
+
+    it 'does not save a `chhand_type` if we pass in a null value for `name`' do
+      chhand_type = build(:chhand_type, :name => nil, :en_name => 'Invalid')
+      expect(chhand_type.save).to be false
+    end
+
+    it 'deletes the associated `chhands` when `chhand_type` is destroyed' do
+      chhand_type = create(:chhand_type)
+      create(:chhand, :chhand_type => chhand_type)
+      create(:chhand, :chhand_type => chhand_type)
+      expect { chhand_type.destroy }.to change { Chhand.count }.by(-2)
+    end
+
+    it 'does not save a `chhand_type` if the `name` already exists' do
+      create(:chhand_type, :name => 'ਪੰਚਮਿ ਪਦ', :en_name => 'Fifth Stanza')
+      duplicate_chhand_type = build(:chhand_type, :name => 'ਪੰਚਮਿ ਪਦ', :en_name => 'Another Fifth Stanza')
+      expect(duplicate_chhand_type.save).to be false
+    end
+  end
+end


### PR DESCRIPTION
<img src="https://25.media.tumblr.com/07b9ae04defd00babc9d17a5fd973b65/tumblr_mgwyd8Retv1r7k95zo1_500.gif" alt="Chief Keef" width="256" />

## Description

* Wrote specs to ensure that only the correct stuff can be saved
* Also wrote a migration for `ChhandType` because the `name` should always be unique!
* Updated some annoying `Rubocop` stuff :) 

Closes #21 

## Future Specs to Consider

* We shouldn't be able to save things that have wierd white space like `"  Dohra   "` or `Tribhangi       Chhand"`