### PR TITLE
Add `sequence` to the `Chhand`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 .trunk
 .env
 .DS_STORE
+
+lib/assets/*.csv

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,3 +103,6 @@ RSpec/DescribedClass:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+Rails/NotNullColumn:
+  Enabled: false

--- a/app/models/chhand.rb
+++ b/app/models/chhand.rb
@@ -4,4 +4,7 @@ class Chhand < ApplicationRecord
   belongs_to :chhand_type
   belongs_to :chapter
   has_many :pauris, :dependent => :destroy
+
+  validates :sequence, :presence => true
+  validates :sequence, :uniqueness => { :scope => :chapter_id }
 end

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -2,5 +2,5 @@
 
 class Pauri < ApplicationRecord
   belongs_to :chapter
-  has_one :translation, :class_name => 'pauri_translation', :dependent => :destroy
+  has_one :translation, :class_name => 'PauriTranslation', :dependent => :destroy
 end

--- a/db/migrate/20230408210406_add_sequence_to_chhand.rb
+++ b/db/migrate/20230408210406_add_sequence_to_chhand.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddSequenceToChhand < ActiveRecord::Migration[7.0]
+  def up
+    ##
+    # NOTE:
+    # We forgot to add `sequence` to chhands table.
+    # Luckily, none of the developers have any data in the `chhands` table.
+    # Thus, we have to `.destroy_all` the data in the `chhands` table.
+    #  BONUS NOTE:
+    # The reason we aren't doing TRUNCATE is because we also want the destroy
+    # to cascade to the relevant tables, such as `pauris`, etc.
+    ##
+
+    Chhand.destroy_all
+
+    add_column :chhands, :sequence, :integer, :null => false
+    add_index :chhands, [:chapter_id, :sequence], :unique => true
+  end
+
+  def down
+    remove_index :chhands, [:chapter_id, :sequence]
+    remove_column :chhands, :sequence
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_07_143116) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_08_210406) do
   create_table "books", force: :cascade do |t|
     t.integer "sequence", null: false
     t.string "title", null: false
@@ -52,6 +52,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_07_143116) do
     t.string "vaak"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sequence", null: false
+    t.index ["chapter_id", "sequence"], name: "index_chhands_on_chapter_id_and_sequence", unique: true
     t.index ["chapter_id"], name: "index_chhands_on_chapter_id"
     t.index ["chhand_type_id"], name: "index_chhands_on_chhand_type_id"
   end
@@ -94,6 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_07_143116) do
     t.datetime "updated_at", null: false
     t.index ["chapter_id"], name: "index_tuks_on_chapter_id"
     t.index ["pauri_id"], name: "index_tuks_on_pauri_id"
+    t.index ["sequence", "pauri_id"], name: "index_tuks_on_sequence_and_pauri_id", unique: true
   end
 
   add_foreign_key "chapters", "books"

--- a/spec/factories/chhands.rb
+++ b/spec/factories/chhands.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :chhand do
     association :chhand_type
     association :chapter
+    add_attribute(:sequence) { '1' }
   end
 end

--- a/spec/models/chhand_spec.rb
+++ b/spec/models/chhand_spec.rb
@@ -9,44 +9,50 @@ RSpec.describe Chhand do
   describe 'validations' do
     context 'when given valid attributes' do
       it 'saves the `Chhand`' do
-        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :vaak => 'Example vaak')
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :vaak => 'Example vaak', :sequence => 1)
         expect(chhand).to be_valid
       end
 
       it 'saves the `Chhand` without `vaak`' do
-        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter)
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :sequence => 1)
         expect(chhand).to be_valid
       end
     end
 
     context 'when given invalid attributes' do
       it 'does not save the `Chhand` without a `chhand_type`' do
-        chhand = Chhand.new(:chapter => chapter, :vaak => 'Example vaak')
+        chhand = Chhand.new(:chapter => chapter, :vaak => 'Example vaak', :sequence => 1)
         expect(chhand).not_to be_valid
       end
 
       it 'does not save the `Chhand` without a `chapter`' do
-        chhand = Chhand.new(:chhand_type => chhand_type, :vaak => 'Example vaak')
+        chhand = Chhand.new(:chhand_type => chhand_type, :vaak => 'Example vaak', :sequence => 1)
         expect(chhand).not_to be_valid
       end
 
       it 'does not save the `Chhand` with a non-existent `chhand_type_id`' do
-        chhand = Chhand.new(:chhand_type_id => 999, :chapter => chapter, :vaak => 'Example vaak')
+        chhand = Chhand.new(:chhand_type_id => 999, :chapter => chapter, :vaak => 'Example vaak', :sequence => 1)
         expect(chhand).not_to be_valid
       end
 
       it 'does not save the `Chhand` with a non-existent `chapter_id`' do
-        chhand = Chhand.new(:chhand_type => chhand_type, :chapter_id => 999, :vaak => 'Example vaak')
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter_id => 999, :vaak => 'Example vaak', :sequence => 1)
         expect(chhand).not_to be_valid
       end
 
       it 'does not save the `Chhand` with a null `chhand_type`' do
-        chhand = Chhand.new(:chhand_type => nil, :chapter => chapter, :vaak => 'Example vaak')
+        chhand = Chhand.new(:chhand_type => nil, :chapter => chapter, :vaak => 'Example vaak', :sequence => 1)
         expect(chhand).not_to be_valid
       end
 
       it 'does not save the `Chhand` with a null `chapter`' do
-        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => nil, :vaak => 'Example vaak')
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => nil, :vaak => 'Example vaak', :sequence => 1)
+        expect(chhand).not_to be_valid
+      end
+
+      it 'does not save the `Chhand` with a duplicate `sequence` within the same `chapter`' do
+        create(:chhand, :chapter => chapter, :sequence => 1)
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :vaak => 'Example vaak', :sequence => 1)
         expect(chhand).not_to be_valid
       end
     end

--- a/spec/models/chhand_spec.rb
+++ b/spec/models/chhand_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Chhand do
-  let(:chhand_type) { create(:chhand_type) }
-  let(:chapter) { create(:chapter) }
+  let!(:chhand_type) { create(:chhand_type) }
+  let!(:chapter) { create(:chapter) }
 
   describe 'validations' do
     context 'when given valid attributes' do
@@ -51,8 +51,8 @@ RSpec.describe Chhand do
       end
 
       it 'does not save the `Chhand` with a duplicate `sequence` within the same `chapter`' do
-        create(:chhand, :chapter => chapter, :sequence => 1)
-        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :vaak => 'Example vaak', :sequence => 1)
+        create(:chhand, :chhand_type => chhand_type, :chapter => chapter, :sequence => 1)
+        chhand = Chhand.new(:chhand_type => chhand_type, :chapter => chapter, :sequence => 1)
         expect(chhand).not_to be_valid
       end
     end


### PR DESCRIPTION
<!-- Ensure the Pull Request has a descriptive title -->

<!-- Optional: Change this GIF -->
<img src="https://media0.giphy.com/media/Ekb6vyhrKX6kE/giphy.gif" alt="" width="256" />

# Description

We forgot to add a `sequence` to the `Chhand` table. 

However, this migration was a little bit tricky. I'll explain:

In the real world, if we wanted to add a `sequence: integer` to a database, it wouldn't be a problem! However, we specifically had a constraint that said:

> **sequence cannot be null**

If the migration runs, it will fail because... we are adding a new column... and we don't know what the value is, so it's going to be `null`... but we just said that IT CANNOT BE NULL.

Fair enough; when this happens in a production application, you can set a "default" value, such as `0`. But, we had another constraint that said:

> **it must be unique depending on the chapter**

## However... We Are Lucky

We are lucky, because most of our database is empty or not allocated with "real" data. So, what I did is... I `destroy`ed all the  `Chhands`. 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies or commands that are required for this change. -->

## New Changes

* New migration
* Updated factory
* Updated specs

Closes #38 

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->

<!-- Add an "x" to check things off -->

* [x] Added/Updated Specs
* [x] Manual Test

<!-- ## Screenshots or Videos -->
<!-- If applicable, include any screenshots or videos that help showcase the changes made. -->

<!-- ## Next Steps -->
<!-- If there are any future enhancements or changes to be made, please describe them here. -->
