### PR TITLE
31 make number on the pauris table mandatory

### DIFF
--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -6,4 +6,6 @@ class Pauri < ApplicationRecord
   has_one :translation, :class_name => 'PauriTranslation', :dependent => :destroy
   has_one :external_pauri, :dependent => :destroy
   has_many :tuks, :dependent => :destroy
+
+  validates: number, uniqueness: { scope: :chapter_id, message: "Should be unique within a chapter" }
 end

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -8,4 +8,6 @@ class Pauri < ApplicationRecord
   has_many :tuks, :dependent => :destroy
 
   validates :number, :uniqueness => { :scope => :chapter_id }
+  validates :number, :presence => true
+  validates :number, :numericality => { :greater_than => 0 }
 end

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -7,5 +7,5 @@ class Pauri < ApplicationRecord
   has_one :external_pauri, :dependent => :destroy
   has_many :tuks, :dependent => :destroy
 
-  validates: number, uniqueness: { scope: :chapter_id, message: "Should be unique within a chapter" }
+  validates :number, :uniqueness => { :scope => :chapter_id }
 end

--- a/db/migrate/20230405183333_create_pauris.rb
+++ b/db/migrate/20230405183333_create_pauris.rb
@@ -3,7 +3,7 @@
 class CreatePauris < ActiveRecord::Migration[7.0]
   def change
     create_table :pauris do |t|
-      t.integer :number
+      t.integer :number, :null => false
       t.references :chapter, :foreign_key => true, :null => false
       t.references :chhand, :foreign_key => true, :null => false
 

--- a/db/migrate/20230414160208_add_unique_index_on_pauri_number_and_chapter.rb
+++ b/db/migrate/20230414160208_add_unique_index_on_pauri_number_and_chapter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnPauriNumberAndChapter < ActiveRecord::Migration[7.0]
+  def change
+    add_index :pauris, [:number, :chapter_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_10_215505) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_160208) do
   create_table "books", force: :cascade do |t|
     t.integer "sequence", null: false
     t.string "title", null: false
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_10_215505) do
     t.datetime "updated_at", null: false
     t.index ["chapter_id"], name: "index_pauris_on_chapter_id"
     t.index ["chhand_id"], name: "index_pauris_on_chhand_id"
+    t.index ["number", "chapter_id"], name: "index_pauris_on_number_and_chapter_id", unique: true
   end
 
   create_table "tuk_footnotes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_10_215505) do
   end
 
   create_table "pauris", force: :cascade do |t|
-    t.integer "number"
+    t.integer "number", null: false
     t.integer "chapter_id", null: false
     t.integer "chhand_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
# Description
Made changes so that a `pauri number` can't be null, added a validation in the `pauri model` so that a `chapter` only has unique `pauri number`s, and added an index for unique `pauri number`s and `chapter_id` in a new migration

## New Changes
- Added  `:null => false` for `pauri number`
- Added  `add_index :pauris, [:number, :chapter_id], :unique => true` in a new migration
- Added the following to the `pauri` model
    1. `validates :number, :presence => true`
    2. `validates :number, :numericality => { :greater_than => 0 }`



Closes #31 
Closes #33 
