### PR TITLE
Create `PauriFootnotes`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 
 /public/assets
+/node_modules
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -6,6 +6,7 @@ class Pauri < ApplicationRecord
   has_one :translation, :class_name => 'PauriTranslation', :dependent => :destroy
   has_one :external_pauri, :dependent => :destroy
   has_many :tuks, :dependent => :destroy
+  has_one :footnote, :class_name => 'PauriFootnote', :dependent => :destroy
 
   validates :number, :uniqueness => { :scope => :chapter_id }
   validates :number, :presence => true

--- a/app/models/pauri_footnote.rb
+++ b/app/models/pauri_footnote.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class PauriFootnote < ApplicationRecord
+  belongs_to :pauri
+  validates :contentful_entry_id, :uniqueness => true
+end

--- a/db/migrate/20230508124727_create_pauri_footnotes.rb
+++ b/db/migrate/20230508124727_create_pauri_footnotes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePauriFootnotes < ActiveRecord::Migration[7.0]
   def change
     create_table :pauri_footnotes do |t|

--- a/db/migrate/20230508124727_create_pauri_footnotes.rb
+++ b/db/migrate/20230508124727_create_pauri_footnotes.rb
@@ -1,0 +1,11 @@
+class CreatePauriFootnotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pauri_footnotes do |t|
+      t.references :pauri, :foreign_key => true, :null => false, :index => true
+      t.text :bhai_vir_singh_footnote
+      t.string :contentful_entry_id, :index => { :unique => true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_14_160208) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_08_124727) do
   create_table "books", force: :cascade do |t|
     t.integer "sequence", null: false
     t.string "title", null: false
@@ -66,6 +66,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_14_160208) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pauri_id"], name: "index_external_pauris_on_pauri_id"
+  end
+
+  create_table "pauri_footnotes", force: :cascade do |t|
+    t.integer "pauri_id", null: false
+    t.text "bhai_vir_singh_footnote"
+    t.string "contentful_entry_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contentful_entry_id"], name: "index_pauri_footnotes_on_contentful_entry_id", unique: true
+    t.index ["pauri_id"], name: "index_pauri_footnotes_on_pauri_id"
   end
 
   create_table "pauri_translations", force: :cascade do |t|
@@ -124,6 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_14_160208) do
   add_foreign_key "chhands", "chapters"
   add_foreign_key "chhands", "chhand_types"
   add_foreign_key "external_pauris", "pauris"
+  add_foreign_key "pauri_footnotes", "pauris"
   add_foreign_key "pauri_translations", "pauris"
   add_foreign_key "pauris", "chapters"
   add_foreign_key "pauris", "chhands"


### PR DESCRIPTION
<!-- Ensure the Pull Request has a descriptive title -->

<!-- Optional: Change this GIF -->
<img src="https://media.tenor.com/ybuSNn5DjvQAAAAd/tion-wayne-tion-wayne-wid-it.gif" alt="Tion Wayne dancing" width="256" />

# Description
Sometimes an entire `pauri` has a `footnote`. This PR adds the `pauri_footnotes` migration.

Need to get this merged to unblock #51 

## New Changes
* New migration file
* New model
* Added the relevant associations (`@pauri.footnote`)

<!-- Remove the line below if there is no GitHub Issue -->
Closes #44 

## How Has This Been Tested?
<!-- Add an "x" to check things off -->

* [ ] Added/Updated Specs
* [x] Manual Test

## Screenshots or Videos

<img width="956" alt="Screen Shot 2023-05-08 at 8 49 48 AM" src="https://user-images.githubusercontent.com/17516559/236829997-55dac512-37e2-4ecd-83ca-964799809bc2.png">

<img width="951" alt="Screen Shot 2023-05-08 at 8 49 57 AM" src="https://user-images.githubusercontent.com/17516559/236829923-bcdb0a13-095d-4f17-a944-3f5a1cb2149b.png">


<!-- ## Next Steps -->
<!-- If there are any future enhancements or changes to be made, please describe them here. -->
