### PR TITLE
Add SoundCloud Support

### DIFF
--- a/app/models/katha.rb
+++ b/app/models/katha.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Katha < ApplicationRecord
-  belongs_to :giani
-  has_many :chapter_kathas, :dependent => :destroy
-  has_many :chapters, :through => :chapter_kathas, :dependent => :destroy
+  belongs_to :giani, :optional => true
+  has_one :chapter_katha, :dependent => :destroy
+  has_one :chapter, :through => :chapter_katha, :dependent => :destroy
 end

--- a/app/views/chapters/kathas.json.jbuilder
+++ b/app/views/chapters/kathas.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.key_format! :camelize => :lower
 
-# :kathas => { :id, :gianiId, :title, :publicUrl, :soundcloudUrl, :year }
+# :kathas => { :id, :gianiId, :title, :publicUrl, :isPlaylist, :soundcloudUrl, :year }
 json.kathas do
-  json.array!(@kathas, :id, :giani_id, :title, :public_url, :soundcloud_url, :year)
+  json.array!(@kathas, :id, :giani_id, :title, :public_url, :is_playlist, :soundcloud_url, :year)
 end

--- a/db/migrate/20230611172633_add_soundcloud_playlist_support_to_katha.rb
+++ b/db/migrate/20230611172633_add_soundcloud_playlist_support_to_katha.rb
@@ -1,0 +1,5 @@
+class AddSoundcloudPlaylistSupportToKatha < ActiveRecord::Migration[7.0]
+  def change
+    add_column :kathas, :is_playlist, :boolean, :default => false
+  end
+end

--- a/db/migrate/20230611172633_add_soundcloud_playlist_support_to_katha.rb
+++ b/db/migrate/20230611172633_add_soundcloud_playlist_support_to_katha.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSoundcloudPlaylistSupportToKatha < ActiveRecord::Migration[7.0]
   def change
     add_column :kathas, :is_playlist, :boolean, :default => false

--- a/db/migrate/20230611191536_remove_null_constraint_from_giani_id_on_kathas.rb
+++ b/db/migrate/20230611191536_remove_null_constraint_from_giani_id_on_kathas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveNullConstraintFromGianiIdOnKathas < ActiveRecord::Migration[7.0]
   def change
     change_column_null :kathas, :giani_id, true

--- a/db/migrate/20230611191536_remove_null_constraint_from_giani_id_on_kathas.rb
+++ b/db/migrate/20230611191536_remove_null_constraint_from_giani_id_on_kathas.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintFromGianiIdOnKathas < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :kathas, :giani_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_11_172633) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_11_191536) do
   create_table "books", force: :cascade do |t|
     t.integer "sequence", null: false
     t.string "title", null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_11_172633) do
   end
 
   create_table "kathas", force: :cascade do |t|
-    t.integer "giani_id", null: false
+    t.integer "giani_id"
     t.string "title"
     t.string "public_url"
     t.string "soundcloud_url"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_03_170655) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_11_172633) do
   create_table "books", force: :cascade do |t|
     t.integer "sequence", null: false
     t.string "title", null: false
@@ -92,6 +92,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_03_170655) do
     t.integer "year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_playlist", default: false
     t.index ["giani_id"], name: "index_kathas_on_giani_id"
   end
 


### PR DESCRIPTION
<!-- Ensure the Pull Request has a descriptive title -->

<!-- Optional: Change this GIF -->
<img src="https://media0.giphy.com/media/3o7WTxyMSVN7lM5I7C/giphy.gif?cid=6c09b952a75fe0759e3ed93b49b1b4f2e38e05becd3f966b&ep=v1_internal_gifs_gifId&rid=giphy.gif&ct=g" alt="Another one" width="256" />


## Description

Before, the `Katha` and `ChapterKatha` represented one audio file. Meaning, if Giani Sher Singh and Raqbewala had a katha on a specific chapter, it would be saved in 2 different records in the `kathas` and `chapter_kathas` tables. 

However, we want to add support for SoundCloud when some reads a chapter on the `https://spg.dev/chapters/:id` page. 

**In this PR**, I have set up the groundwork to allow the [`ReadChapterScreen` (in shaheedi-spg) to play SoundCloud playlists.](https://github.com/vidhiya-saagar/shaheedi-spg/pull/20/files#diff-d8202eea6fb53bf5ed34d1cab6d39411dccc495ffe5b9b03b653ff7812576cc6R111-R117)

## New Changes
* Migrations
* Update API


<!-- Remove the line below if there is no GitHub Issue -->
Closes #65 

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->

<!-- Add an "x" to check things off -->

* [x] Added/Updated Specs
* [ ] Manual Test

## Screenshots or Videos

<img width="1440" alt="PNG image" src="https://github.com/vidhiya-saagar/spg2/assets/17516559/6048df7a-1f19-4d13-bfc6-856b2258ab32">


<!-- ## Next Steps -->
<!-- If there are any future enhancements or changes to be made, please describe them here. -->
