### PR TITLE
Add rate limiting for Footnote importing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lib/imports/*/*.csv
 node_modules
 
 *.csv
+.vscode/*

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -4,6 +4,7 @@ class Chapter < ApplicationRecord
   belongs_to :book
   has_many :chhands, :dependent => :destroy
   has_many :pauris, :dependent => :destroy
+  has_many :pauri_translations, :through => :pauris
   has_many :tuks, :through => :pauris
   has_many :chapter_kathas, :dependent => :destroy
   has_many :kathas, :through => :chapter_kathas

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -3,7 +3,7 @@
 class Pauri < ApplicationRecord
   belongs_to :chapter
   belongs_to :chhand
-  has_one :pauri_translation
+  has_one :pauri_translation, :dependent => :destroy
   has_one :translation, :class_name => 'PauriTranslation', :dependent => :destroy
   has_one :external_pauri, :dependent => :destroy
   has_many :tuks, :dependent => :destroy

--- a/app/models/pauri.rb
+++ b/app/models/pauri.rb
@@ -3,6 +3,7 @@
 class Pauri < ApplicationRecord
   belongs_to :chapter
   belongs_to :chhand
+  has_one :pauri_translation
   has_one :translation, :class_name => 'PauriTranslation', :dependent => :destroy
   has_one :external_pauri, :dependent => :destroy
   has_many :tuks, :dependent => :destroy

--- a/app/services/contentful_pauri_importer.rb
+++ b/app/services/contentful_pauri_importer.rb
@@ -53,8 +53,24 @@ class ContentfulPauriImporter
   #   Returns an array of JSON objects like this:
   #   [{id: "6fy52qIYDK8EyisyaaBe4o", entry_name: "Book 1 Chapter 1 Pauri 13"}, {...}, {...}]
   #   @entries = ContentfulPauriImporter.new.entries
+  # def entries
+  #   return @client.entries(:content_type => 'pauriFootnote').map { |e| { :id => e.id, :entry_name => e.entry_name } }
+  # end
+
   def entries
-    return @client.entries(:content_type => 'pauriFootnote').map { |e| { :id => e.id, :entry_name => e.entry_name } }
+    all_entries = []
+    limit = 1000
+    skip = 0
+    total = 1
+
+    while all_entries.size < total
+      response = @client.entries(:content_type => 'pauriFootnote', :limit => limit, :skip => skip)
+      total = response.total
+      all_entries += response.items.map { |e| { :id => e.id, :entry_name => e.entry_name } }
+      skip += limit
+    end
+
+    return all_entries
   end
 
   # ContentfulPauriImporter.new.latest_entries

--- a/app/services/contentful_tuk_importer.rb
+++ b/app/services/contentful_tuk_importer.rb
@@ -66,6 +66,7 @@ class ContentfulTukImporter
 
   # ContentfulTukImporter.new.import_latest_entries
   def import_latest_entries
+    # new_entries = self.entries
     new_entries = self.latest_entries
     new_entries.each do |e|
       metadata = self.extract_info(e[:entry_name])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
   get '/chapters/:id', to: 'chapters#show'
   get '/chapters/:id/content', to: 'chapters#content'
   get '/chapters/:id/kathas', to: 'chapters#kathas'
-  post '/chapters/webhook', to: 'chapters#webhook'
 
   # Book routes
   get '/books', to: 'books#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,14 +3,16 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  resources :chapters, :only => [:show] do 
-    get 'content', on: :member
-    get 'kathas', on: :member
-  end
-  
-  resources :books, :only => [:index, :show]
+  # Chapter routes
+  get '/chapters/:id', to: 'chapters#show'
+  get '/chapters/:id/content', to: 'chapters#content'
+  get '/chapters/:id/kathas', to: 'chapters#kathas'
+  post '/chapters/webhook', to: 'chapters#webhook'
 
-  resources :books do
-    resources :chapters, :only => [:index]
-  end
+  # Book routes
+  get '/books', to: 'books#index'
+  get '/books/:id', to: 'books#show'
+  
+  # Nested book chapters route
+  get '/books/:book_id/chapters', to: 'chapters#index'
 end


### PR DESCRIPTION
<!-- Ensure the Pull Request has a descriptive title -->

<!-- Optional: Change this GIF -->
<img src="https://media.tenor.com/RSLZbG4tcCIAAAAC/kill-bill-uma-thurman.gif" alt="" width="256" />

# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies or commands that are required for this change. -->

I did this a while ago. I don't quite remember what it was though.

I think it was because we have a lot of footnotes in Contentful and before... it used to import ALL at once... 

## How Has This Been Tested?

I imported footnotes a while back! 

<!-- Add an "x" to check things off -->

* [ ] Added/Updated Specs
* [x] Manual Test

<!-- ## Screenshots or Videos -->
<!-- If applicable, include any screenshots or videos that help showcase the changes made. -->

<!-- ## Next Steps -->
<!-- If there are any future enhancements or changes to be made, please describe them here. -->
